### PR TITLE
Correctly pack the integers 0 and 1

### DIFF
--- a/direct/src/distributed/AstronInternalRepository.py
+++ b/direct/src/distributed/AstronInternalRepository.py
@@ -29,9 +29,9 @@ def msgpack_length(dg, length, fix, maxfix, tag8, tag16, tag32):
 def msgpack_encode(dg, element):
     if element == None:
         dg.addUint8(0xc0)
-    elif element == False:
+    elif element is False:
         dg.addUint8(0xc2)
-    elif element == True:
+    elif element is True:
         dg.addUint8(0xc3)
     elif isinstance(element, (int, long)):
         if -32 <= element < 128:


### PR DESCRIPTION
``` python
element = 0

element == False
# True

element is False
# False
```

Currently, this msgpack implementation was packing 0 as 'false' and 1 as 'true'. All other ints were packed correctly.
